### PR TITLE
chore: add tsify case 1

### DIFF
--- a/tsconfig.no-any.json
+++ b/tsconfig.no-any.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "include": [
-    "app/module-one/feature-one"
+    "app/module-one/feature-one",
+    "app/module-one/feature-two"
   ],
   "compilerOptions": {
     "baseUrl": "./",


### PR DESCRIPTION
# Overview
Added a new module `app/module-one/feature-two` to reproduce 'no-any' issues and facilitate testing with the TSify Migrator.

## Steps to Reproduce
1. Make sure you have installed all the dependencies by running `yarn`
2. Run the TSify Migrator: `yarn tsify-migrator`

## Expected Behavior
```
$ node ./scripts/tsifyMigrator/tsifyMigrator.mjs
app/module-one/feature-two/CountryList.tsx(6,20): error TS7006: Parameter 'item' implicitly has an 'any' type.

ERROR: noImplicitAny failed -> Please fix the missing modules/files shown above.
Local debugger command: yarn tsc -b ./tsconfig.json | grep -E 'app/module-one/feature-one|app/module-one/feature-two'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```